### PR TITLE
fixes issue #7

### DIFF
--- a/src/qt3utils/experiments/cwodmr.py
+++ b/src/qt3utils/experiments/cwodmr.py
@@ -264,7 +264,6 @@ class CWODMR:
 
         '''
 
-        self.edge_counter_config.reset_daq()
         self.N_cycles = int(N_cycles)
 
         self.rfsynth.stop_sweep()

--- a/src/qt3utils/experiments/podmr.py
+++ b/src/qt3utils/experiments/podmr.py
@@ -424,7 +424,6 @@ class PulsedODMR:
 
         '''
 
-        self.edge_counter_config.reset_daq()
         self.N_cycles = int(N_cycles)
 
         self.rfsynth.stop_sweep()

--- a/src/qt3utils/experiments/rabi.py
+++ b/src/qt3utils/experiments/rabi.py
@@ -432,9 +432,6 @@ class Rabi:
 
         '''
 
-        self.edge_counter_config.reset_daq()
-        ## TODO: add cleanup for edge counter... attempt to stop / close tasks
-
         self.N_cycles = int(N_cycles)
 
         self.rfsynth.stop_sweep()

--- a/src/qt3utils/experiments/t1coherence.py
+++ b/src/qt3utils/experiments/t1coherence.py
@@ -249,9 +249,6 @@ class T1Coherence:
 
         '''
 
-        self.edge_counter_config.reset_daq()
-        ## TODO: add cleanup for edge counter... attempt to stop / close tasks
-
         self.N_cycles = int(N_cycles)
 
 


### PR DESCRIPTION
removes reset daq calls. reseting the daq would reset all output
channels, including analog outputs connected to piezo stage.